### PR TITLE
fix #1 call addref in queryinterface

### DIFF
--- a/derive-com-impl/src/derive.rs
+++ b/derive-com-impl/src/derive.rs
@@ -122,6 +122,8 @@ impl<'a> ComImpl<'a> {
                         return winapi::shared::winerror::E_POINTER;
                     }
                     if #( #is_equal_iid )||* {
+                        let that = &*(this as *const Self);
+                        that.#refcount.add_ref();
                         *ppv = this as *mut winapi::ctypes::c_void;
                         winapi::shared::winerror::S_OK
                     } else {


### PR DESCRIPTION
Fix #1 

According to https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-queryinterface(refiid_void) 
QueryInterface must call AddRef before returning pointer

Tested on the problem I had, I can confirm it fixes the negative refcount.
